### PR TITLE
Fix compilation with clang

### DIFF
--- a/ext/radix.c
+++ b/ext/radix.c
@@ -333,7 +333,7 @@ static VALUE rb_radix_delete(int argc, VALUE *argv, VALUE self)
  *   radix.search_best(key[, prefixlen]) -> hash
  *
  * Return a value from the database by locating the key string
- * provided. 
+ * provided.
  * Search strategy is to match best suited for the key.
  * If the key is not found, returns nil.
  */
@@ -385,7 +385,7 @@ rb_radix_search_best(int argc, VALUE *argv, VALUE self)
  *   radix.search_best(key[, prefixlen]) -> hash
  *
  * Return a value from the database by locating the key string
- * provided. 
+ * provided.
  * Search strategy is to match exactly. If the key is not found,
  * returns nil.
  */
@@ -502,7 +502,7 @@ rb_radix_keys(VALUE self)
 			RaiseModified(gen_id_cur, radixp->gen_id);
 			if (rn->data != NULL) {
 				prefix_ntop(rn->prefix, prefix, sizeof(prefix));
-				rb_ary_push(ary, rb_tainted_str_new(
+				rb_ary_push(ary, rb_str_new(
 						    prefix, strlen(prefix)));
 			}
 		} RADIX_WALK_END;
@@ -591,7 +591,7 @@ rb_radix_each_key(VALUE self)
 			RaiseModified(gen_id_cur, radixp->gen_id);
 			if (rn->data != NULL) {
 				prefix_ntop(rn->prefix, prefix, sizeof(prefix));
-				rb_yield(rb_tainted_str_new(prefix,
+				rb_yield(rb_str_new(prefix,
 							    strlen(prefix)));
 			}
 		} RADIX_WALK_END;
@@ -656,7 +656,7 @@ rb_radix_each_pair(VALUE self)
 			RaiseModified(gen_id_cur, radixp->gen_id);
 			if (rn->data != NULL) {
 				prefix_ntop(rn->prefix, prefix, sizeof(prefix));
-				keystr = rb_tainted_str_new(prefix,
+				keystr = rb_str_new(prefix,
 							    strlen(prefix));
 				rb_yield(rb_assoc_new(keystr, (VALUE)rn->data));
 			}
@@ -694,7 +694,7 @@ rb_radix_to_hash(VALUE self)
 			RaiseModified(gen_id_cur, radixp->gen_id);
 			if (rn->data != NULL) {
 				prefix_ntop(rn->prefix, prefix, sizeof(prefix));
-				keystr = rb_tainted_str_new(prefix,
+				keystr = rb_str_new(prefix,
 							    strlen(prefix));
 				rb_hash_aset(hash, keystr, (VALUE)rn->data);
 			}
@@ -769,7 +769,7 @@ rb_rn_prefix_get(VALUE self)
 
 	prefix_ntop(&rn->prefix, prefix, sizeof(prefix));
 
-	return rb_tainted_str_new(prefix, strlen(prefix));
+	return rb_str_new(prefix, strlen(prefix));
 }
 
 static VALUE
@@ -782,7 +782,7 @@ rb_rn_network_get(VALUE self)
 
 	prefix_addr_ntop(&rn->prefix, prefix, sizeof(prefix));
 
-	return rb_tainted_str_new(prefix, strlen(prefix));
+	return rb_str_new(prefix, strlen(prefix));
 }
 
 static VALUE

--- a/ext/radix.c
+++ b/ext/radix.c
@@ -93,7 +93,7 @@ static void rn_mark(struct radixnode *);
 
 /*-------- class Radix --------*/
 
-static int
+static struct radixdata*
 init_radixdata(struct radixdata *radixp)
 {
 	radix_tree_t *rt4, *rt6;
@@ -318,7 +318,7 @@ static VALUE rb_radix_delete(int argc, VALUE *argv, VALUE self)
 	}
 	if (node->data != NULL) {
 		node->data = NULL;
-	}		
+	}
 
 	radix_remove(PICKRT(prefix, radixp), node);
 	Deref_Prefix(prefix);


### PR DESCRIPTION
But as far as I can see these could be generally sane fixes.

Errors fixed:

- error: call to undeclared function 'rb_tainted_str_new'
- error: incompatible pointer to integer conversion returning 'void *' from a function with result type 'int'

I'm opening this PR just for more discoverability, not as a real intention to keep it to master.

See https://github.com/iij/ruby-radix/issues/2